### PR TITLE
Use local pest.erl if possible

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,6 @@
 - id: pest
   name: SAST:pest - Erlang Security Testing (via Docker build)
   description: Run PEST SAST for Erlang (via Docker build)
-  language: docker
+  language: script
   files: "[.]erl$"
-  entry: "/pest/pest.erl"
-  args: ["-ev"]
+  entry: run_pest.sh

--- a/run_pest.sh
+++ b/run_pest.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+## Check if pest is in path
+PEST=`which pest.erl`
+ESCRIPT=`which escript`
+if [[ -f "$PEST" ]]
+then
+    pest.erl -ev $1
+else
+    if [[ -f "$ESCRIPT" ]]
+    then
+        echo "INFO: For quicker workflow, git clone https://github.com/okeuday/pest and add pest.erl to $PATH"
+    fi
+
+    DIR=`dirname "${BASH_SOURCE[0]}"`
+    HASH=`git --git-dir=$DIR/.git rev-parse --short HEAD`
+    NAME="pre-commit-erlang-pest"
+    docker build $DIR --tag $NAME:$HASH
+    docker run --rm -v $PWD:/src:rw,Z --workdir /src $NAME:$HASH "/pest/pest.erl" -ev $1
+fi
+


### PR DESCRIPTION
docker has it's own set of issues, and if the user has pest.erl installed locally, then use it instead of docker.